### PR TITLE
Prepare configuration for release to PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,8 @@ classifiers = [
     "Development Status :: 1 - Planning",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.6,<3.9"  # RayOcular only supports Python 3.6 and 3.8
-dependencies = [
-    "numpy",
-    "pythonnet>=2.5.2",
-]
+requires-python = ">=3.6,<3.9" # RayOcular only supports Python 3.6 and 3.8
+dependencies = ["numpy", "pythonnet>=2.5.2"]
 dynamic = ["version"]
 
 # Hatch configuration
@@ -32,8 +29,11 @@ dynamic = ["version"]
 source = "versioningit"
 default-version = "0.0.0+unknown"
 
+[tool.hatch.build.targets.sdist]
+exclude = [".github/", "docs/"]
+
 [tool.hatch.build.targets.wheel]
-packages = [ "pyrot" ]
+packages = ["pyrot"]
 
 # Testing
 
@@ -52,30 +52,28 @@ target-version = "py38"
 
 line-length = 120
 extend-include = ["*.ipynb"]
-exclude = [
-    "Examples/",
-]
+exclude = ["Examples/"]
 
 [tool.ruff.lint]
 preview = true
 extend-select = [
-    "LOG015",  # Root logger call
+    "LOG015", # Root logger call
 ]
 ignore = [
-    "RUF009",  # Function as dataclass default
-    "EM", # exception messages
+    "RUF009", # Function as dataclass default
+    "EM",     # exception messages
     "TRY003", # accept longer exception messages 
-    "S101", # accept use of assert as this is of use in RayOcular scripting
-    "N806", # TODO: snake_case implementation in next merge request
-    "N803", #TODO: snake_case implementation in next merge request
-    "N802", #TODO: snake_case implementation in next merge request
-    "PYI019"  # typing.Self is not available in Python 3.8
+    "S101",   # accept use of assert as this is of use in RayOcular scripting
+    "N806",   # TODO: snake_case implementation in next merge request
+    "N803",   #TODO: snake_case implementation in next merge request
+    "N802",   #TODO: snake_case implementation in next merge request
+    "PYI019", # typing.Self is not available in Python 3.8
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = [
-    "PLC2701",  # Private members
-    "PLR6301"
+    "PLC2701", # Private members
+    "PLR6301",
 ]
 
 [tool.ruff.lint.flake8-pytest-style]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling", "versioningit"]
 build-backend = "hatchling.build"
 
 [project]
-name = "pyROT"
+name = "rayocular-toolbox"
 authors = [
     { name = "Jan-Willem Beenakker" },
     { name = "Lennart Pors" },
@@ -13,7 +13,7 @@ maintainers = [{ name = "MReye research group", email = "pyrot@mreye.nl" }]
 
 description = "A Python toolbox for ocular proton therapy planning in RayOcular"
 readme = "README.md"
-license = { file = "LICENSE.txt" }
+license = { file = "LICENSE" }
 keywords = ["RayOcular", "RayStation", "Proton therapy"]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -31,6 +31,9 @@ dynamic = ["version"]
 [tool.hatch.version]
 source = "versioningit"
 default-version = "0.0.0+unknown"
+
+[tool.hatch.build.targets.wheel]
+packages = [ "pyrot" ]
 
 # Testing
 


### PR DESCRIPTION
- Renames the project to `rayocular-toolbox`;
- Fix incorrect license file reference in `pyproject.toml`

After these changes, pyrot can be installed using

```bash
pip install rayocular-toolbox
```

and still imported as `pyrot`.

Todo:

- [x] Create a project on PyPI @jwmbeenakker 
- [x] Finish #3 so the release can be tested