### PR TITLE
Implement JSON saving and loading for `EyeModel` 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up uv
         id: setup-uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
       - name: Format and lint
         run: uvx hatch fmt --check
 
@@ -21,14 +23,17 @@ jobs:
       matrix:
         python-version: [3.8]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up uv
         id: setup-uv
-        uses: astral-sh/setup-uv@v3
-      - name: Install Python
-        run: uv python install ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync
       - name: Run tests
-        run: uvx hatch test
+        run: uv run pytest ./tests/
       - name: Lint docstrings
         if: always() # Run even if previous step fails
         run: uvx pydocstringformatter --exit-code scripts tests pyrot standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,8 @@ max-line-length = 120
 max-summary-lines = 1
 summary-quotes-same-line = true
 linewrap-full-docstring = true
+
+[dependency-groups]
+dev = [
+    "pytest>=7.0.1",
+]

--- a/pyrot/eye_modelling/datamodels/export.py
+++ b/pyrot/eye_modelling/datamodels/export.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import re
-from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
 from shutil import copy
@@ -194,8 +193,7 @@ def export_eye_model(structure_set, output_directory: Path, eyemodelnr: int):
 
     eye_model = EyeModel.from_rayocular(structure_set.GeometryGenerators[eyemodelnr])
 
-    with open(output_directory / f"eye_model_{eyemodelnr}.json", "w", encoding="utf-8") as f:
-        json.dump(asdict(eye_model), f, indent=4)
+    eye_model.save_json(output_directory / f"eye_model_{eyemodelnr}.json")
 
 
 def export_pois(structure_set, output_directory: Path, examination_name: str):

--- a/pyrot/eye_modelling/datamodels/models.py
+++ b/pyrot/eye_modelling/datamodels/models.py
@@ -153,6 +153,7 @@ class BaseModel:
         if not is_dataclass(cls):
             raise NotImplementedError("from_dict is only implemented for dataclasses.")
 
+        data = data.copy()
         field_types = get_type_hints(cls)
 
         for field in fields(cls):

--- a/pyrot/eye_modelling/datamodels/models.py
+++ b/pyrot/eye_modelling/datamodels/models.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
+import json
 import logging
-from dataclasses import asdict, dataclass, fields, is_dataclass
-from typing import Any, TypeVar
+from dataclasses import MISSING, asdict, dataclass, fields, is_dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypeVar, get_type_hints
 
 from pyrot.eye_modelling.datamodels import validators
 from pyrot.eye_modelling.datamodels.validators import (
     RayOcularField,
+    ValidatedField,
     Vector3,
-    rayocular_field,
 )
+
+if TYPE_CHECKING:
+    from os import PathLike
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +26,8 @@ _Self = TypeVar("_Self")
 class BaseModel:
     """Abstract base class for RayOcular data models.
 
+    For full functionality, all subclasses must be dataclasses and use the `RayOcularField` descriptor to define fields that correspond to RayOcular properties.
+
     Methods
     -------
     from_rayocular(cls, rayocular_object)
@@ -28,6 +35,12 @@ class BaseModel:
 
     to_rayocular(self)
         Converts the data model instance to a RayOcular object.
+
+    to_dict(self)
+        Converts the data model instance to a dictionary.
+
+    from_dict(cls, data)
+        Creates an instance of the data model from a dictionary.
     """
 
     @classmethod
@@ -96,146 +109,250 @@ class BaseModel:
 
         return rayocular_fields
 
+    def to_dict(self) -> dict[str, Any]:
+        """Converts the data model instance to a dictionary.
+
+        This method is only implemented for dataclasses.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary representation of the data model instance.
+
+        Raises
+        ------
+        NotImplementedError
+            If the data model instance is not a dataclass.
+        """
+        if is_dataclass(self):
+            return asdict(self)
+
+        raise NotImplementedError("to_dict is only implemented for dataclasses.")
+
+    @classmethod
+    def from_dict(cls: type[_Self], data: dict[str, Any]) -> _Self:
+        """Creates an instance of the data model from a dictionary.
+
+        This method is only implemented for dataclasses.
+
+        Parameters
+        ----------
+        data : dict[str, Any]
+            A dictionary representation of the data model instance.
+
+        Returns
+        -------
+        BaseModel
+            An instance of the data model.
+
+        Raises
+        ------
+        NotImplementedError
+            If the data model class is not a dataclass.
+        """
+        if not is_dataclass(cls):
+            raise NotImplementedError("from_dict is only implemented for dataclasses.")
+
+        field_types = get_type_hints(cls)
+
+        for field in fields(cls):
+            field_type = field_types.get(field.name)
+
+            if field_type is None or isinstance(field_type, str):
+                raise TypeError(f"Failed to resolve type for field {field.name} in class {cls.__name__}.")
+
+            if field.name not in data:
+                if field.default is MISSING:
+                    raise ValueError(f"Missing field {field.name} in data.")
+
+                data[field.name] = field.default
+
+        return cls(**data)
+
 
 @dataclass
 class EyeModelMeasurements(BaseModel):
-    cornea_lens_distance: float = rayocular_field(validators.positive_float, "CorneaLensDistance")
-    eye_length: float = rayocular_field(validators.positive_float, "EyeLength")
-    eye_width: float = rayocular_field(validators.positive_float, "EyeWidth")
-    lens_thickness: float = rayocular_field(validators.positive_float, "LensThickness")
-    limbus_diameter: float = rayocular_field(validators.positive_float, "LimbusDiameter")
+    cornea_lens_distance: RayOcularField[float] = RayOcularField(validators.positive_float, "CorneaLensDistance")
+    eye_length: RayOcularField[float] = RayOcularField(validators.positive_float, "EyeLength")
+    eye_width: RayOcularField[float] = RayOcularField(validators.positive_float, "EyeWidth")
+    lens_thickness: RayOcularField[float] = RayOcularField(validators.positive_float, "LensThickness")
+    limbus_diameter: RayOcularField[float] = RayOcularField(validators.positive_float, "LimbusDiameter")
 
 
 @dataclass
 class AnteriorChamber(BaseModel):
-    local_rotation: Vector3[float] = rayocular_field(validators.vector3(float), "ChamberLocalRotation")
-    local_scale: Vector3[float] = rayocular_field(validators.vector3(validators.positive_float), "ChamberLocalScale")
-    local_translation: Vector3[float] = rayocular_field(validators.vector3(float), "ChamberLocalTranslation")
+    local_rotation: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "ChamberLocalRotation")
+    local_scale: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(validators.positive_float), "ChamberLocalScale"
+    )
+    local_translation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "ChamberLocalTranslation"
+    )
 
 
 @dataclass
 class CiliaryBody(BaseModel):
-    base_curvature: float = rayocular_field(float, "CiliaryBodyBaseCurvature")
-    height: float = rayocular_field(validators.positive_float, "CiliaryBodyHeight")
-    local_rotation: Vector3[float] = rayocular_field(validators.vector3(float), "CiliaryBodyLocalRotation")
-    local_scale: Vector3[float] = rayocular_field(
+    base_curvature: RayOcularField[float] = RayOcularField(float, "CiliaryBodyBaseCurvature")
+    height: RayOcularField[float] = RayOcularField(validators.positive_float, "CiliaryBodyHeight")
+    local_rotation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "CiliaryBodyLocalRotation"
+    )
+    local_scale: RayOcularField[Vector3[float]] = RayOcularField(
         validators.vector3(validators.positive_float), "CiliaryBodyLocalScale"
     )
-    local_translation: Vector3[float] = rayocular_field(validators.vector3(float), "CiliaryBodyLocalTranslation")
+    local_translation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "CiliaryBodyLocalTranslation"
+    )
 
 
 @dataclass
 class Cornea(BaseModel):
-    local_rotation: Vector3[float] = rayocular_field(validators.vector3(float), "CorneaLocalRotation")
-    local_scale: Vector3[float] = rayocular_field(validators.vector3(validators.positive_float), "CorneaLocalScale")
-    local_translation: Vector3[float] = rayocular_field(validators.vector3(float), "CorneaLocalTranslation")
-    semi_axis: Vector3[float] = rayocular_field(validators.vector3(float), "CorneaSemiAxis")
-    thickness: float = rayocular_field(validators.positive_float, "CorneaThickness")
+    local_rotation: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "CorneaLocalRotation")
+    local_scale: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(validators.positive_float), "CorneaLocalScale"
+    )
+    local_translation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "CorneaLocalTranslation"
+    )
+    semi_axis: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "CorneaSemiAxis")
+    thickness: RayOcularField[float] = RayOcularField(validators.positive_float, "CorneaThickness")
 
 
 @dataclass
 class Eye(BaseModel):
-    pivot: Vector3[float] = rayocular_field(validators.vector3(float), "EyePivot")
-    rotation: Vector3[float] = rayocular_field(validators.vector3(float), "EyeRotation")
-    scale: Vector3[float] = rayocular_field(validators.vector3(validators.positive_float), "EyeScale")
-    translation: Vector3[float] = rayocular_field(validators.vector3(float), "EyeTranslation")
+    pivot: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "EyePivot")
+    rotation: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "EyeRotation")
+    scale: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(validators.positive_float), "EyeScale")
+    translation: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "EyeTranslation")
 
 
 @dataclass
 class Iris(BaseModel):
-    inner_semi_axis: Vector3[float] = rayocular_field(validators.vector3(float), "IrisInnerSemiAxis")
-    outer_semi_axis: Vector3[float] = rayocular_field(validators.vector3(float), "IrisOuterSemiAxis")
-    local_rotation: Vector3[float] = rayocular_field(validators.vector3(float), "IrisLocalRotation")
-    local_scale: Vector3[float] = rayocular_field(validators.vector3(validators.positive_float), "IrisLocalScale")
-    local_translation: Vector3[float] = rayocular_field(validators.vector3(float), "IrisLocalTranslation")
-    thickness: float = rayocular_field(validators.positive_float, "IrisThickness")
+    inner_semi_axis: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "IrisInnerSemiAxis")
+    outer_semi_axis: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "IrisOuterSemiAxis")
+    local_rotation: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "IrisLocalRotation")
+    local_scale: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(validators.positive_float), "IrisLocalScale"
+    )
+    local_translation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "IrisLocalTranslation"
+    )
+    thickness: RayOcularField[float] = RayOcularField(validators.positive_float, "IrisThickness")
 
 
 @dataclass
 class Lens(BaseModel):
-    curvature: float = rayocular_field(float, "LensCurvature")
-    local_rotation: Vector3[float] = rayocular_field(validators.vector3(float), "LensLocalRotation")
-    local_scale: Vector3[float] = rayocular_field(validators.vector3(validators.positive_float), "LensLocalScale")
-    local_translation: Vector3[float] = rayocular_field(validators.vector3(float), "LensLocalTranslation")
-    semi_axis: Vector3[float] = rayocular_field(validators.vector3(float), "LensSemiAxis")
+    curvature: RayOcularField[float] = RayOcularField(float, "LensCurvature")
+    local_rotation: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "LensLocalRotation")
+    local_scale: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(validators.positive_float), "LensLocalScale"
+    )
+    local_translation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "LensLocalTranslation"
+    )
+    semi_axis: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "LensSemiAxis")
 
 
 @dataclass
 class Macula(BaseModel):
-    height: float = rayocular_field(validators.positive_float, "MaculaHeight")
-    local_rotation: Vector3[float] = rayocular_field(validators.vector3(float), "MaculaLocalRotation")
-    local_scale: Vector3[float] = rayocular_field(validators.vector3(validators.positive_float), "MaculaLocalScale")
-    local_translation: Vector3[float] = rayocular_field(validators.vector3(float), "MaculaLocalTranslation")
-    rotation: Vector3[float] = rayocular_field(validators.vector3(float), "MaculaRotation")
-    semi_axis: Vector3[float] = rayocular_field(validators.vector3(float), "MaculaSemiAxis")
+    height: RayOcularField[float] = RayOcularField(validators.positive_float, "MaculaHeight")
+    local_rotation: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "MaculaLocalRotation")
+    local_scale: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(validators.positive_float), "MaculaLocalScale"
+    )
+    local_translation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "MaculaLocalTranslation"
+    )
+    rotation: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "MaculaRotation")
+    semi_axis: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "MaculaSemiAxis")
 
 
 @dataclass
 class OpticalDisc(BaseModel):
-    height: float = rayocular_field(validators.positive_float, "OpticalDiscHeight")
-    local_rotation: Vector3[float] = rayocular_field(validators.vector3(float), "OpticalDiscLocalRotation")
-    local_scale: Vector3[float] = rayocular_field(
+    height: RayOcularField[float] = RayOcularField(validators.positive_float, "OpticalDiscHeight")
+    local_rotation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "OpticalDiscLocalRotation"
+    )
+    local_scale: RayOcularField[Vector3[float]] = RayOcularField(
         validators.vector3(validators.positive_float), "OpticalDiscLocalScale"
     )
-    local_translation: Vector3[float] = rayocular_field(validators.vector3(float), "OpticalDiscLocalTranslation")
-    semi_axis: Vector3[float] = rayocular_field(validators.vector3(float), "OpticalDiscSemiAxis")
+    local_translation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "OpticalDiscLocalTranslation"
+    )
+    semi_axis: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "OpticalDiscSemiAxis")
 
 
 @dataclass
 class OpticalNerve(BaseModel):
-    height: float = rayocular_field(validators.positive_float, "OpticalNerveHeight")
-    local_rotation: Vector3[float] = rayocular_field(validators.vector3(float), "OpticalNerveLocalRotation")
-    local_scale: Vector3[float] = rayocular_field(
+    height: RayOcularField[float] = RayOcularField(validators.positive_float, "OpticalNerveHeight")
+    local_rotation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "OpticalNerveLocalRotation"
+    )
+    local_scale: RayOcularField[Vector3[float]] = RayOcularField(
         validators.vector3(validators.positive_float), "OpticalNerveLocalScale"
     )
-    local_translation: Vector3[float] = rayocular_field(validators.vector3(float), "OpticalNerveLocalTranslation")
-    rotation: Vector3[float] = rayocular_field(validators.vector3(float), "OpticalNerveRotation")
-    semi_axis: Vector3[float] = rayocular_field(validators.vector3(float), "OpticalNerveSemiAxis")
+    local_translation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "OpticalNerveLocalTranslation"
+    )
+    rotation: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "OpticalNerveRotation")
+    semi_axis: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "OpticalNerveSemiAxis")
 
 
 @dataclass
 class Retina(BaseModel):
-    thickness: float = rayocular_field(validators.positive_float, "RetinaThickness")
-    local_rotation: Vector3[float] = rayocular_field(validators.vector3(float), "RetinaLocalRotation")
-    local_scale: Vector3[float] = rayocular_field(validators.vector3(validators.positive_float), "RetinaLocalScale")
-    local_translation: Vector3[float] = rayocular_field(validators.vector3(float), "RetinaLocalTranslation")
+    thickness: RayOcularField[float] = RayOcularField(validators.positive_float, "RetinaThickness")
+    local_rotation: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "RetinaLocalRotation")
+    local_scale: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(validators.positive_float), "RetinaLocalScale"
+    )
+    local_translation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "RetinaLocalTranslation"
+    )
 
 
 @dataclass
 class Sclera(BaseModel):
-    thickness: float = rayocular_field(validators.positive_float, "ScleraThickness")
-    local_rotation: Vector3[float] = rayocular_field(validators.vector3(float), "ScleraLocalRotation")
-    local_scale: Vector3[float] = rayocular_field(validators.vector3(validators.positive_float), "ScleraLocalScale")
-    local_translation: Vector3[float] = rayocular_field(validators.vector3(float), "ScleraLocalTranslation")
-    semi_axis: Vector3[float] = rayocular_field(validators.vector3(float), "ScleraSemiAxis")
+    thickness: RayOcularField[float] = RayOcularField(validators.positive_float, "ScleraThickness")
+    local_rotation: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "ScleraLocalRotation")
+    local_scale: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(validators.positive_float), "ScleraLocalScale"
+    )
+    local_translation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "ScleraLocalTranslation"
+    )
+    semi_axis: RayOcularField[Vector3[float]] = RayOcularField(validators.vector3(float), "ScleraSemiAxis")
 
 
 @dataclass
 class VitreousBody(BaseModel):
-    local_rotation: Vector3[float] = rayocular_field(validators.vector3(float), "VitreousBodyLocalRotation")
-    local_scale: Vector3[float] = rayocular_field(
+    local_rotation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "VitreousBodyLocalRotation"
+    )
+    local_scale: RayOcularField[Vector3[float]] = RayOcularField(
         validators.vector3(validators.positive_float), "VitreousBodyLocalScale"
     )
-    local_translation: Vector3[float] = rayocular_field(validators.vector3(float), "VitreousBodyLocalTranslation")
+    local_translation: RayOcularField[Vector3[float]] = RayOcularField(
+        validators.vector3(float), "VitreousBodyLocalTranslation"
+    )
 
 
 @dataclass
-class EyeModelParameters:
-    eye: Eye = rayocular_field(validators.dataclass(Eye))
-    anterior_chamber: AnteriorChamber = rayocular_field(validators.dataclass(AnteriorChamber))
-    ciliary_body: CiliaryBody = rayocular_field(validators.dataclass(CiliaryBody))
-    cornea: Cornea = rayocular_field(validators.dataclass(Cornea))
-    iris: Iris = rayocular_field(validators.dataclass(Iris))
-    lens: Lens = rayocular_field(validators.dataclass(Lens))
-    macula: Macula = rayocular_field(validators.dataclass(Macula))
-    optical_disc: OpticalDisc = rayocular_field(validators.dataclass(OpticalDisc))
-    optical_nerve: OpticalNerve = rayocular_field(validators.dataclass(OpticalNerve))
-    retina: Retina = rayocular_field(validators.dataclass(Retina))
-    sclera: Sclera = rayocular_field(validators.dataclass(Sclera))
-    vitreous_body: VitreousBody = rayocular_field(validators.dataclass(VitreousBody))
+class EyeModelParameters(BaseModel):
+    eye: ValidatedField[Eye] = ValidatedField(validators.dataclass(Eye))
+    anterior_chamber: ValidatedField[AnteriorChamber] = ValidatedField(validators.dataclass(AnteriorChamber))
+    ciliary_body: ValidatedField[CiliaryBody] = ValidatedField(validators.dataclass(CiliaryBody))
+    cornea: ValidatedField[Cornea] = ValidatedField(validators.dataclass(Cornea))
+    iris: ValidatedField[Iris] = ValidatedField(validators.dataclass(Iris))
+    lens: ValidatedField[Lens] = ValidatedField(validators.dataclass(Lens))
+    macula: ValidatedField[Macula] = ValidatedField(validators.dataclass(Macula))
+    optical_disc: ValidatedField[OpticalDisc] = ValidatedField(validators.dataclass(OpticalDisc))
+    optical_nerve: ValidatedField[OpticalNerve] = ValidatedField(validators.dataclass(OpticalNerve))
+    retina: ValidatedField[Retina] = ValidatedField(validators.dataclass(Retina))
+    sclera: ValidatedField[Sclera] = ValidatedField(validators.dataclass(Sclera))
+    vitreous_body: ValidatedField[VitreousBody] = ValidatedField(validators.dataclass(VitreousBody))
 
-    lens_cornea_distance: float = rayocular_field(validators.positive_float)
-    level_of_detail: int = rayocular_field(int)
+    lens_cornea_distance: ValidatedField[float] = ValidatedField(validators.positive_float)
+    level_of_detail: ValidatedField[int] = ValidatedField(int)
 
     @classmethod
     def from_rayocular(cls, parameters) -> EyeModelParameters:
@@ -275,10 +392,20 @@ class EyeModelParameters:
         }
 
 
+EyeLaterality = Literal["Left", "Right"]
+
+
 @dataclass
-class EyeModel:
-    measurements: EyeModelMeasurements = rayocular_field(validators.dataclass(EyeModelMeasurements))
-    parameters: EyeModelParameters = rayocular_field(validators.dataclass(EyeModelParameters))
+class EyeModel(BaseModel):
+    measurements: ValidatedField[EyeModelMeasurements] = ValidatedField(validators.dataclass(EyeModelMeasurements))
+    parameters: ValidatedField[EyeModelParameters] = ValidatedField(validators.dataclass(EyeModelParameters))
+    laterality: RayOcularField[EyeLaterality] = RayOcularField(validators.literal(EyeLaterality), "Laterality")
+
+    description: RayOcularField[str] = RayOcularField(str, "Description", default="")
+    inter_pupillary_distance: RayOcularField[Optional[float]] = RayOcularField(
+        validators.optional(validators.positive_float), "InterPupillaryDistance", default=None
+    )
+    name: RayOcularField[str] = RayOcularField(str, "Name", default="Eye Model")
 
     @classmethod
     def from_rayocular(cls, geometry_generator) -> EyeModel:
@@ -286,6 +413,24 @@ class EyeModel:
         parameters = geometry_generator.EyeModelParameters
 
         return cls(
+            description=geometry_generator.Description,
+            inter_pupillary_distance=geometry_generator.InterPupillaryDistance,
+            laterality=geometry_generator.Laterality,
+            name=geometry_generator.Name,
             measurements=EyeModelMeasurements.from_rayocular(measurements),
             parameters=EyeModelParameters.from_rayocular(parameters),
         )
+
+    def to_rayocular(self) -> dict[str, Any]:
+        raise NotImplementedError("to_rayocular is not implemented for EyeModel.")
+
+    @classmethod
+    def load_json(cls, file_path: PathLike | str) -> EyeModel:
+        file_path = Path(file_path)
+        data = json.loads(file_path.read_text(encoding="utf-8"))
+
+        return cls.from_dict(data)
+
+    def save_json(self, file_path: PathLike | str) -> None:
+        file_path = Path(file_path)
+        file_path.write_text(json.dumps(self.to_dict(), indent=4), encoding="utf-8")

--- a/pyrot/eye_modelling/datamodels/validators.py
+++ b/pyrot/eye_modelling/datamodels/validators.py
@@ -125,7 +125,7 @@ class RayOcularField(ValidatedField[Value]):
     ----------
     validator : Callable[[Any], Value]
         A callable object that performs the validation.
-    name : str | None
+    name : str
         The RayOcular name of the field. This is used for serialization and deserialization to RayOcular.
     default : Value, optional
         The default value for the field. If not provided, the field will be required and must be set explicitly.
@@ -167,7 +167,7 @@ class RayOcularField(ValidatedField[Value]):
     ...         self.age = age
     """
 
-    def __init__(self, validator: Callable[[Any], Value], name: str | None, *, default: Value = ...) -> None:
+    def __init__(self, validator: Callable[[Any], Value], name: str, *, default: Value = ...) -> None:
         self.rayocular_name = name
         self.validator = validator
         self._default = default

--- a/pyrot/eye_modelling/datamodels/validators.py
+++ b/pyrot/eye_modelling/datamodels/validators.py
@@ -37,7 +37,7 @@ class ValidatedField(Generic[Value]):
     ----------
     validator : Callable[[Any], Value]
         A callable object that performs the validation.
-    default: Value, optional
+    default : Value, optional
         The default value for the field. If not provided, the field will be required and must be set explicitly.
 
     Attributes
@@ -125,9 +125,9 @@ class RayOcularField(ValidatedField[Value]):
     ----------
     validator : Callable[[Any], Value]
         A callable object that performs the validation.
-    name: str | None
+    name : str | None
         The RayOcular name of the field. This is used for serialization and deserialization to RayOcular.
-    default: Value, optional
+    default : Value, optional
         The default value for the field. If not provided, the field will be required and must be set explicitly.
 
     Attributes
@@ -173,8 +173,31 @@ class RayOcularField(ValidatedField[Value]):
         self._default = default
 
 
-def dataclass(cls: type[Value]) -> Callable[..., Value]:
-    def validate(value) -> Value:
+T = TypeVar("T")
+
+
+def dataclass(cls: type[T]) -> Callable[..., T]:
+    """Validator for dataclasses.
+
+    Checks if the value is an instance of the dataclass or a dict that can be used to create an instance of the dataclass.
+
+    Parameters
+    ----------
+    cls : type[T]
+        The dataclass type to validate against.
+
+    Returns
+    -------
+    Callable[..., T]
+        A validator function that can be used to validate instances of the dataclass.
+
+    Raises
+    ------
+    ValueError
+        If the value is not an instance of the dataclass or a dict that can be used to create an instance of the dataclass.
+    """
+
+    def validate(value) -> T:
         if isinstance(value, cls):
             return value
 
@@ -187,6 +210,23 @@ def dataclass(cls: type[Value]) -> Callable[..., Value]:
 
 
 def positive_float(value: Any) -> float:
+    """Validator for positive floats.
+
+    Parameters
+    ----------
+    value : Any
+        The value to validate.
+
+    Returns
+    -------
+    float
+        The validated positive float value.
+
+    Raises
+    ------
+    ValueError
+        If the value is not a positive float.
+    """
     if isinstance(value, float) and value >= 0:
         return value
 
@@ -195,18 +235,33 @@ def positive_float(value: Any) -> float:
 
 # Use a dataclass because of JSON serialization
 @dataclasses.dataclass(frozen=True)
-class Vector3(Generic[Value]):
-    x: Value
-    y: Value
-    z: Value
-
-
-T = TypeVar("T")
+class Vector3(Generic[T]):
+    x: T
+    y: T
+    z: T
 
 
 def vector3(
     item_validator: Callable[..., T],
 ) -> Callable[[Any], Vector3[T]]:
+    """Validator for Vector3 objects.
+
+    Parameters
+    ----------
+    item_validator : Callable[..., T]
+        A validator function for the individual components of the vector.
+
+    Returns
+    -------
+    Callable[[Any], Vector3[T]]
+        A validator function that can be used to validate Vector3 objects.
+
+    Raises
+    ------
+    ValueError
+        If the value is not a valid Vector3 object.
+    """
+
     def validate(value: Any) -> Vector3[T]:
         if isinstance(value, Vector3):
             return value
@@ -227,9 +282,22 @@ def vector3(
 
 
 def literal(type_: type[T]) -> Callable[[Any], T]:
+    """Validator for literal values.
+
+    Parameters
+    ----------
+    type_ : type[T]
+        The type containing the allowed literal values.
+
+    Returns
+    -------
+    Callable[[Any], T]
+        A validator function that can be used to validate literal values.
+    """
+
     def validate(value: Any) -> T:
-        allowed = get_args(type_)  # type: ignore
-        if value in allowed:  # type: ignore
+        allowed = get_args(type_)
+        if value in allowed:
             return value
 
         raise ValueError(f"Expected one of {allowed}, got {value}.")
@@ -238,6 +306,19 @@ def literal(type_: type[T]) -> Callable[[Any], T]:
 
 
 def optional(inner: Callable[..., T]) -> Callable[[Any], T | None]:
+    """Validator for optional values.
+
+    Parameters
+    ----------
+    inner : Callable[..., T]
+        The validator function for the non-optional value.
+
+    Returns
+    -------
+    Callable[[Any], T | None]
+        A validator function to validate optional values.
+    """
+
     def validate(value: Any) -> T | None:
         if value is None:
             return None

--- a/pyrot/eye_modelling/datamodels/validators.py
+++ b/pyrot/eye_modelling/datamodels/validators.py
@@ -29,6 +29,10 @@ class RayOcularField(Generic[Instance, Value]):
     ----------
     validator : Callable[[Any], Value]
         A callable object that performs the validation.
+    name: str | None
+        The RayOcular name of the field. This is used for serialization and deserialization to RayOcular.
+    default: Value, optional
+        The default value for the field. If not provided, the field will be required and must be set explicitly.
 
     Attributes
     ----------
@@ -67,15 +71,19 @@ class RayOcularField(Generic[Instance, Value]):
     ...         self.age = age
     """
 
-    def __init__(self, validator: Callable[[Any], Value], name: str | None) -> None:
+    def __init__(self, validator: Callable[[Any], Value], name: str | None, *, default: Value = ...) -> None:
         self.rayocular_name = name
         self.validator = validator
+        self._default = default
 
     def __set_name__(self, owner: Instance, name: str):
         self.public_name = name
         self.private_name = "_" + name
 
     def __get__(self, instance: Instance, owner: type[Instance] | None = None) -> Value:
+        if instance is None and self._default is not ...:
+            return self._default
+
         return getattr(instance, self.private_name)
 
     def __set__(self, instance: Instance, value: Value):
@@ -107,22 +115,24 @@ class RayOcularField(Generic[Instance, Value]):
 
 # Factory function to create a validated field.
 # This is needed to make type checkers accept validated fields for type-annotated fields.
-def rayocular_field(validator: Callable[[Any], Value], name: str | None = None) -> Value:
+def rayocular_field(validator: Callable[[Any], Value], name: str | None = None, *, default: Value = ...) -> Value:
     """Creates a validated field with the given validator.
 
     Parameters
     ----------
-    name : str
-        The RayOcular name of the field.
     validator : Callable[[Any], Value]
         A callable object that takes any value as input and returns a validated value.
+    name : str | None
+        The RayOcular name of the field.
+    default : Value, optional
+        The default value for the field. If not provided, the field will be required and must be set explicitly.
 
     Returns
     -------
     ValidatedField[Instance, Value]
         The validated field.
     """
-    return RayOcularField(validator, name)  # type: ignore
+    return RayOcularField(validator, name, default=default)  # type: ignore
 
 
 def dataclass(cls: type[Value]) -> Callable[..., Value]:

--- a/pyrot/eye_modelling/datamodels/validators.py
+++ b/pyrot/eye_modelling/datamodels/validators.py
@@ -4,11 +4,19 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from typing import Any, Callable, Generic, Mapping, Sequence, TypeVar
+from typing import Any, Callable, Generic, Mapping, Sequence, TypeVar, get_args
 
-__all__ = ["Vector3", "dataclass", "positive_float", "rayocular_field", "vector3"]
+__all__ = [
+    "RayOcularField",
+    "ValidationError",
+    "Vector3",
+    "dataclass",
+    "literal",
+    "optional",
+    "positive_float",
+    "vector3",
+]
 
-Instance = TypeVar("Instance")
 Value = TypeVar("Value")
 
 logger = logging.getLogger(__name__)
@@ -22,8 +30,96 @@ class ValidationError(Exception):
         super().__init__(self.message)
 
 
-class RayOcularField(Generic[Instance, Value]):
+class ValidatedField(Generic[Value]):
     """A descriptor class that provides validation for a field.
+
+    Parameters
+    ----------
+    validator : Callable[[Any], Value]
+        A callable object that performs the validation.
+    default: Value, optional
+        The default value for the field. If not provided, the field will be required and must be set explicitly.
+
+    Attributes
+    ----------
+    public_name : str
+        The public name of the field.
+    private_name : str
+        The private name of the field.
+
+    Methods
+    -------
+    __get__(self, instance: Instance, owner: type[Instance] | None = None) -> Value:
+        Retrieves the value of the field.
+
+    __set__(self, instance: Instance, value: Value):
+        Sets the value of the field after validating it.
+
+    validate(self, value):
+        Validates the given value using the provided validator.
+
+    Raises
+    ------
+    ValueError
+        If the validation fails.
+
+    Notes
+    -----
+    Define a `ValidatedField` descriptor for a class attribute and provide a validator function.
+    The validator function should take a single argument and return the validated value.
+
+    Examples
+    --------
+    >>> class Person:
+    ...     age = ValidatedField(int)
+    ...
+    ...     def __init__(self, age):
+    ...         self.age = age
+    """
+
+    def __init__(self, validator: Callable[[Any], Value], *, default: Value = ...) -> None:
+        self.validator = validator
+        self._default = default
+
+    def __set_name__(self, owner, name: str):
+        self.public_name = name
+        self.private_name = "_" + name
+
+    def __get__(self, instance, owner: type | None = None) -> Value:
+        if instance is None and self._default is not ...:
+            return self._default
+
+        return getattr(instance, self.private_name)
+
+    def __set__(self, instance, value: Value) -> None:
+        setattr(instance, self.private_name, self.validate(value))
+
+    def validate(self, value: Value) -> Value:
+        """Validates the given value using the provided validator.
+
+        Parameters
+        ----------
+        value : Any
+            The value to be validated.
+
+        Returns
+        -------
+        Value
+            The validated value.
+
+        Raises
+        ------
+        ValueError
+            If the validation fails.
+        """
+        try:
+            return self.validator(value)
+        except ValueError as e:
+            raise ValidationError(value, self.public_name) from e
+
+
+class RayOcularField(ValidatedField[Value]):
+    """A descriptor class that provides validation for a RayOcular field.
 
     Parameters
     ----------
@@ -76,64 +172,6 @@ class RayOcularField(Generic[Instance, Value]):
         self.validator = validator
         self._default = default
 
-    def __set_name__(self, owner: Instance, name: str):
-        self.public_name = name
-        self.private_name = "_" + name
-
-    def __get__(self, instance: Instance, owner: type[Instance] | None = None) -> Value:
-        if instance is None and self._default is not ...:
-            return self._default
-
-        return getattr(instance, self.private_name)
-
-    def __set__(self, instance: Instance, value: Value):
-        setattr(instance, self.private_name, self.validate(value))
-
-    def validate(self, value):
-        """Validates the given value using the provided validator.
-
-        Parameters
-        ----------
-        value : Any
-            The value to be validated.
-
-        Returns
-        -------
-        Value
-            The validated value.
-
-        Raises
-        ------
-        ValueError
-            If the validation fails.
-        """
-        try:
-            return self.validator(value)
-        except ValueError as e:
-            raise ValidationError(value, self.public_name) from e
-
-
-# Factory function to create a validated field.
-# This is needed to make type checkers accept validated fields for type-annotated fields.
-def rayocular_field(validator: Callable[[Any], Value], name: str | None = None, *, default: Value = ...) -> Value:
-    """Creates a validated field with the given validator.
-
-    Parameters
-    ----------
-    validator : Callable[[Any], Value]
-        A callable object that takes any value as input and returns a validated value.
-    name : str | None
-        The RayOcular name of the field.
-    default : Value, optional
-        The default value for the field. If not provided, the field will be required and must be set explicitly.
-
-    Returns
-    -------
-    ValidatedField[Instance, Value]
-        The validated field.
-    """
-    return RayOcularField(validator, name, default=default)  # type: ignore
-
 
 def dataclass(cls: type[Value]) -> Callable[..., Value]:
     def validate(value) -> Value:
@@ -163,13 +201,13 @@ class Vector3(Generic[Value]):
     z: Value
 
 
-Item = TypeVar("Item")
+T = TypeVar("T")
 
 
 def vector3(
-    item_validator: Callable[..., Item],
-) -> Callable[[Any], Vector3[Item]]:
-    def validate(value: Any) -> Vector3[Item]:
+    item_validator: Callable[..., T],
+) -> Callable[[Any], Vector3[T]]:
+    def validate(value: Any) -> Vector3[T]:
         if isinstance(value, Vector3):
             return value
         if isinstance(value, Sequence):  # list-like values
@@ -184,5 +222,26 @@ def vector3(
             return Vector3(**{k: item_validator(v) for (k, v) in value.items()})
 
         raise ValueError(f"Could not parse {value=} to Vector3. `value` should be Vector3, list or dict.")
+
+    return validate
+
+
+def literal(type_: type[T]) -> Callable[[Any], T]:
+    def validate(value: Any) -> T:
+        allowed = get_args(type_)  # type: ignore
+        if value in allowed:  # type: ignore
+            return value
+
+        raise ValueError(f"Expected one of {allowed}, got {value}.")
+
+    return validate
+
+
+def optional(inner: Callable[..., T]) -> Callable[[Any], T | None]:
+    def validate(value: Any) -> T | None:
+        if value is None:
+            return None
+
+        return inner(value)
 
     return validate


### PR DESCRIPTION
Add `to_dict` and `from_dict` methods to `BaseModel` and `save_json` and `load_json` methods to `EyeModel`. Verified this with a roundtrip on a previously exported model.

Some fields that are required to create the model in RayOcular were missing from the `EyeModel` class. I added these fields:

- `laterality` with **no default value** (i.e. this field must be added to existing JSON files, otherwise imports will fail)
- `description` with a default value of `""`
- `inter_pupillary_distance` with a default value of `None`
- `name` with a default value of `"Eye Model"`